### PR TITLE
Allow dismissal of submenu with escape key

### DIFF
--- a/src/assets/scripts/Pinecone/index.js
+++ b/src/assets/scripts/Pinecone/index.js
@@ -63,6 +63,18 @@ export function menu() {
 					menuButton.setAttribute( 'aria-expanded', false );
 				}
 			} );
+			document.onkeydown = function( evt ) {
+				evt = evt || window.event;
+				let isEscape = false;
+				if ( 'key' in evt ) {
+					isEscape = 'Escape' == evt.key || 'Esc' == evt.key;
+				} else {
+					isEscape = 27 == evt.keyCode;
+				}
+				if ( isEscape ) {
+					menuButton.setAttribute( 'aria-expanded', false );
+				}
+			};
 		} );
 
 		Array.prototype.forEach.call( topLevelMenuItems, topLevelMenuItem => {

--- a/src/assets/styles/components/_menu--home.scss
+++ b/src/assets/styles/components/_menu--home.scss
@@ -1,3 +1,11 @@
+.home .menu-toggle {
+	color: $off-white;
+
+	&:focus {
+		border-color: $off-white;
+	}
+}
+
 @include breakpoint-up(md) {
 	.menu--home {
 		background-color: $blue-500;
@@ -28,10 +36,15 @@
 		box-shadow: 0 rem(3) rem(6) rgba(0, 0, 0, 0.16);
 
 		.menu__item {
+			background-color: $blue-500;
 			padding-left: rem(16);
 
 			&::after {
 				display: none;
+			}
+
+			&:focus {
+				background-color: $off-white;
 			}
 
 			&:hover {

--- a/src/assets/styles/components/_menu.scss
+++ b/src/assets/styles/components/_menu.scss
@@ -297,6 +297,10 @@ nav {
 				display: none;
 			}
 
+			&:focus {
+				background-color: $blue-500;
+			}
+
 			&:hover {
 				background-color: $blue-500;
 				color: $off-white;

--- a/src/assets/styles/layouts/_header.scss
+++ b/src/assets/styles/layouts/_header.scss
@@ -3,6 +3,10 @@
 	width: 100vw;
 }
 
+.home [role="banner"] {
+	background: $blue-500;
+}
+
 @include breakpoint-up(md) {
 	[role="banner"] {
 		padding-left: rem(30);

--- a/src/components/02-molecules/00-menu/menu.config.js
+++ b/src/components/02-molecules/00-menu/menu.config.js
@@ -37,7 +37,8 @@ module.exports = {
 		{
 			'name': 'home',
 			'context': {
-				bodyClass: 'home'
+				bodyClass: 'home',
+				modifier: 'home'
 			}
 		}
 	]


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Currently a submenu in the main navigation can be dismissed by tabbing out of it or by clicking anywhere else on the page. This PR allows it to be dismissed with the `escape` key as well.

## Steps to test

1. Toggle the submenu at https://deploy-preview-79--pinecone.netlify.com/components/preview/menu--default.html
2. Press the `escape` key.

**Expected behavior:** Submenu is dismissed.

## Additional information

Not applicable.

## Related issues

Not applicable.
