### PR TITLE
Improve contrast (fixes #80)

### DIFF
--- a/src/assets/styles/components/_badges.scss
+++ b/src/assets/styles/components/_badges.scss
@@ -11,7 +11,7 @@
 	background: $grey-200;
 	border: solid rem(1) $grey-200;
 	border-radius: rem(3);
-	color: $grey-500;
+	color: $grey-600;
 	display: inline-block;
 	font-family: $font-family-sans;
 	font-size: rem(14);


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Increase badge text contrast.

## Steps to test

Review component: http://deploy-preview-84--pinecone.netlify.com/components/preview/badges.html

## Additional information

Not applicable.

## Related issues

- Fixes #80.
