### PR TITLE
fix: adjust top margin for unfiltered resource list

### DIFF
--- a/src/assets/styles/layouts/_archive.scss
+++ b/src/assets/styles/layouts/_archive.scss
@@ -11,6 +11,10 @@
 	@include grid-column-span(4, 4);
 }
 
+.archive .sort-wrapper + .resource-list {
+	margin-top: ($gutter * -1);
+}
+
 .archive .current-filters {
 	@include grid-column-span(4, 4);
 

--- a/src/assets/styles/layouts/_archive.scss
+++ b/src/assets/styles/layouts/_archive.scss
@@ -11,10 +11,6 @@
 	@include grid-column-span(4, 4);
 }
 
-.archive .sort-wrapper + .resource-list {
-	margin-top: ($gutter * -1);
-}
-
 .archive .current-filters {
 	@include grid-column-span(4, 4);
 
@@ -68,8 +64,8 @@
 		@include grid-column-span(8, 12, 5);
 	}
 
-	.archive .sort-wrapper + .resource-list {
-		margin-top: rem(-24);
+	.archive:not([class*="taxonomy"]) .filter-wrapper {
+		margin-top: rem(24);
 	}
 }
 

--- a/src/assets/styles/layouts/_archive.scss
+++ b/src/assets/styles/layouts/_archive.scss
@@ -67,6 +67,10 @@
 	.archive .current-filters {
 		@include grid-column-span(8, 12, 5);
 	}
+
+	.archive .sort-wrapper + .resource-list {
+		margin-top: rem(-24);
+	}
 }
 
 @include breakpoint-up(xl) {

--- a/src/components/03-layouts/02-archive/archive.config.js
+++ b/src/components/03-layouts/02-archive/archive.config.js
@@ -334,6 +334,16 @@ module.exports = {
 				]
 			},
 		],
-		cards: resourceData
-	}
+		cards: resourceData,
+		foundPosts: 12
+	},
+	variants: [
+		{
+			name: 'Unfiltered',
+			label: 'Unfiltered',
+		context:
+		{		foundPosts: false,
+			currentTags: false
+		}}
+	]
 };

--- a/src/components/03-layouts/02-archive/archive.config.js
+++ b/src/components/03-layouts/02-archive/archive.config.js
@@ -341,9 +341,11 @@ module.exports = {
 		{
 			name: 'Unfiltered',
 			label: 'Unfiltered',
-		context:
-		{		foundPosts: false,
-			currentTags: false
-		}}
+			context:
+			{
+				foundPosts: false,
+				currentTags: false
+			}
+		}
 	]
 };

--- a/src/components/03-layouts/02-archive/archive.config.js
+++ b/src/components/03-layouts/02-archive/archive.config.js
@@ -77,7 +77,7 @@ module.exports = {
 	title: 'Archive',
 	status: 'wip',
 	context: {
-		bodyClass: 'archive',
+		bodyClass: 'archive post-type-archive taxonomy',
 		hasMenu: true,
 		title: 'Browse all',
 		currentTags: [
@@ -343,6 +343,7 @@ module.exports = {
 			label: 'Unfiltered',
 			context:
 			{
+				bodyClass: 'archive post-type-archive',
 				foundPosts: false,
 				currentTags: false
 			}

--- a/src/components/03-layouts/02-archive/archive.njk
+++ b/src/components/03-layouts/02-archive/archive.njk
@@ -20,8 +20,9 @@
 		{% render '@menu-button', {standAlone: true}, true %}
 	</div>
 </div>
+{% if currentTags and foundPosts %}
 <div class="current-filters">
-	<p class="h3">Showing 12 of 742 resources</p>
+	<p class="h3">Showing {{ foundPosts }} of 742 resources</p>
 	<ul class="tag-buttons">
 		{% for tag in currentTags %}
 			{% render '@tag-button', {standAlone: true, label: tag.label} %}
@@ -29,6 +30,7 @@
 	</ul>
 	<p><a href="?x">Clear all <span class="screen-reader-text">filters</span></a></p>
 </div>
+{% endif %}
 <div class="resource-list">
 <ul class="cards">
 {% for card in cards %}


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description
When no filters are applied, the margin between filter/sort and the resource list on the browse page needed to be reduced.

## Steps to test

Review component:

- https://deploy-preview-137--pinecone.netlify.com/components/preview/archive--unfiltered.html

## Additional information

Not applicable.

## Related issues

Not applicable.
