### PR TITLE
fix: resolve specificity issue with banner background color

### DIFF
--- a/src/assets/styles/layouts/_archive.scss
+++ b/src/assets/styles/layouts/_archive.scss
@@ -2,10 +2,6 @@
 	background-color: $off-white;
 }
 
-.archive [role="banner"] {
-	background-color: $white;
-}
-
 .archive .page-header {
 	@include full-width-background($white);
 	@include grid-column-span(4, 4);

--- a/src/assets/styles/layouts/_header.scss
+++ b/src/assets/styles/layouts/_header.scss
@@ -1,10 +1,11 @@
 [role="banner"] {
+	background-color: $white;
 	box-shadow: 0 rem(3) rem(6) rgba(0, 0, 0, 0.16);
 	width: 100vw;
 }
 
 .home [role="banner"] {
-	background: $blue-500;
+	background-color: $blue-500;
 }
 
 .page-header {

--- a/src/assets/styles/layouts/_page.scss
+++ b/src/assets/styles/layouts/_page.scss
@@ -1,10 +1,6 @@
 .page {
 	background-color: $off-white;
 
-	[role="banner"] {
-		background: $white;
-	}
-
 	main {
 		padding-bottom: rem(100);
 	}


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

The home page banner (header area including logo and navigation) has a blue background colour. I applied it using the `.home` class. However, the home page in WordPress has both `.home` and `.page` classes, so this rule was being overridden by the banner colour style for pages. This PR addresses this issue.

## Steps to test

Review menu and home menu components and confirm that the banner areas have the correct background colours:

- https://deploy-preview-146--pinecone.netlify.com/components/preview/menu--default.html
- https://deploy-preview-146--pinecone.netlify.com/components/preview/menu--home.html

## Additional information

Not applicable.

## Related issues

Not applicable.
