### PR TITLE
fix: make icon class names consistent with BEM syntax

### DIFF
--- a/src/assets/styles/components/_menu.scss
+++ b/src/assets/styles/components/_menu.scss
@@ -62,7 +62,7 @@ nav {
 	}
 }
 
-[aria-expanded="false"] .icon-close {
+[aria-expanded="false"] .icon--close {
 	display: none;
 }
 
@@ -70,7 +70,7 @@ nav {
 	display: none;
 }
 
-[aria-expanded="true"] .icon-open {
+[aria-expanded="true"] .icon--open {
 	display: none;
 }
 

--- a/src/components/01-atoms/_svg/_svg.njk
+++ b/src/components/01-atoms/_svg/_svg.njk
@@ -1,5 +1,5 @@
 <svg
-	class="icon icon-{{ class if class else svg }}"
+	class="icon icon--{{ class if class else svg }}"
 	{% for attribute, value in attributes %}
 	{{ attribute | replace('ariaHidden', 'aria-hidden') }}="{{ value }}"
 	{% endfor %}>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR aligns the default class names for SVG icons with [BEM syntax](http://getbem.com/naming/). Each icon has a default class of `.icon`, and a modifier class of `.icon--<icon>` (e.g. `.icon--close`).

## Steps to test

Verify that icon and menu components still display correct icons:

- https://deploy-preview-147--pinecone.netlify.com/components/preview/icons.html
- https://deploy-preview-147--pinecone.netlify.com/components/preview/menu--default.html

## Additional information

Not applicable.

## Related issues

Not applicable.
