### PR TITLE
feat: add automatic publishing to GitHub Package Registry

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,18 @@
+name: Publish package
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://npm.pkg.github.com
+        scope: '@platform-coop-toolkit'
+    - run: npm ci
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/publishing-nodejs-packages#publishing-packages-to-github-packages

## Steps to test

Publish a release, see what happens!

## Additional information

Not applicable.

## Related issues

Not applicable.
