### PR TITLE
fix: speed up disclosure icon animations

### DIFF
--- a/src/assets/styles/components/_accordion.scss
+++ b/src/assets/styles/components/_accordion.scss
@@ -43,7 +43,7 @@
 		height: rem(20);
 		margin-bottom: 0;
 		margin-right: rem(10);
-		transition: transform 0.5s;
+		transition: transform 0.3s;
 		width: rem(20);
 
 		@media (prefers-reduced-motion: reduce) {

--- a/src/assets/styles/components/_disclosure-button.scss
+++ b/src/assets/styles/components/_disclosure-button.scss
@@ -1,6 +1,6 @@
 .disclosure-button {
 	svg {
-		transition: transform 0.5s;
+		transition: transform 0.3s;
 
 		@media (prefers-reduced-motion: reduce) {
 			transition: none;

--- a/src/assets/styles/components/_menu.scss
+++ b/src/assets/styles/components/_menu.scss
@@ -104,7 +104,7 @@ nav {
 
 	/* stylelint-disable no-descending-specificity */
 	svg { /* stylelint-enable */
-		transition: transform 0.5s;
+		transition: transform 0.3s;
 
 		@media (prefers-reduced-motion: reduce) {
 			transition: none;


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Speeds up animation for dropdown menu, accordion, and disclosure button icons to 0.3s.

## Steps to test

Review components:

- https://deploy-preview-158--pinecone.netlify.com/components/preview/menu--default.html
- https://deploy-preview-158--pinecone.netlify.com/components/preview/accordion--default.html
- https://deploy-preview-158--pinecone.netlify.com/components/preview/disclosure-button.html

## Additional information

Not applicable.

## Related issues

Not applicable.