### PR TITLE
feat: add inverse link and CTA variants

### DIFF
--- a/src/assets/styles/components/_buttons.scss
+++ b/src/assets/styles/components/_buttons.scss
@@ -20,7 +20,7 @@
 	}
 }
 
-.has-dark-mint-500-background-color .wp-block-button__link {
+.wp-block-button--inverse .wp-block-button__link {
 	border-color: $white;
 }
 
@@ -81,7 +81,7 @@
 	}
 }
 
-.has-dark-mint-500-background-color .wp-block-button__link:focus {
+.wp-block-button--inverse .wp-block-button__link:focus {
 	box-shadow: 0 0 0 rem(2) $blue-700, 0 0 0 rem(4) $white, 0 0 0 rem(1) $white inset;
 }
 

--- a/src/assets/styles/components/_buttons.scss
+++ b/src/assets/styles/components/_buttons.scss
@@ -1,7 +1,7 @@
 .wp-block-button__link,
 [type="submit"] {
 	background: $blue-500;
-	border: solid 1px transparent;
+	border: solid rem(1) transparent;
 	border-radius: rem(3);
 	color: $white;
 	display: block;
@@ -18,6 +18,10 @@
 	.icon {
 		margin-left: rem(4);
 	}
+}
+
+.has-dark-mint-500-background-color .wp-block-button__link {
+	border-color: $white;
 }
 
 [type="submit"]::-moz-focus-inner {
@@ -75,6 +79,10 @@
 			0 0 0 rem(2) $white,
 			0 0 0 rem(4) $yellow-600;
 	}
+}
+
+.has-dark-mint-500-background-color .wp-block-button__link:focus {
+	box-shadow: 0 0 0 rem(2) $blue-700, 0 0 0 rem(4) $white, 0 0 0 rem(1) $white inset;
 }
 
 .wp-block-button__link:active:focus {

--- a/src/assets/styles/components/_forms.scss
+++ b/src/assets/styles/components/_forms.scss
@@ -212,7 +212,14 @@ input[type="checkbox"]:disabled:hover + label::before {
 	box-shadow: none;
 }
 
-input[type="radio"]:checked:focus + label::before,
+input[type="radio"]:checked:focus + label::before {
+	box-shadow:
+		0 0 0 rem(2) $white,
+		0 0 0 rem(4) $blue-400,
+		0 0 0 rem(1) $blue-400 inset,
+		0 0 0 rem(3) $white inset;
+}
+
 input[type="checkbox"]:checked:focus + label::before,
 [role="checkbox"][aria-checked="true"]:focus::before,
 [role="checkbox"][aria-checked="mixed"]:focus::before {

--- a/src/assets/styles/components/_links.scss
+++ b/src/assets/styles/components/_links.scss
@@ -4,7 +4,6 @@
 	font-family: $font-family-sans;
 	font-weight: $font-weight-semibold;
 	line-height: 1;
-	padding-top: rem(4);
 	text-decoration: underline;
 	text-decoration-color: $blue-400;
 	text-decoration-thickness: rem(1);
@@ -26,10 +25,11 @@
 			margin-bottom: -0.3125em;
 			margin-left: 0;
 			mask: url("../images/chevron-right.svg") no-repeat center;
-			mask-size: 100%;
+			mask-position: left;
+			mask-size: 1.25em;
 			position: relative;
 			text-decoration: underline;
-			width: 1.25em;
+			width: 1em;
 		}
 	}
 
@@ -90,12 +90,14 @@
 		&[rel="external"] {
 			&::after {
 				mask-image: url("../images/external.svg");
+				width: 1.25em;
 			}
 		}
 
 		&[href^="#"] {
 			&::after {
 				mask-image: url("../images/scroll-down.svg");
+				width: 1.25em;
 			}
 		}
 	}

--- a/src/assets/styles/components/_links.scss
+++ b/src/assets/styles/components/_links.scss
@@ -1,4 +1,4 @@
-a:not([class]) {
+%link {
 	color: $blue-500;
 	display: inline-block;
 	font-family: $font-family-sans;
@@ -23,7 +23,7 @@ a:not([class]) {
 			content: "";
 			display: inline-block;
 			height: 1.25em;
-			margin-bottom: rem(-5);
+			margin-bottom: -0.3125em;
 			margin-left: 0;
 			mask: url("../images/chevron-right.svg") no-repeat center;
 			mask-size: 100%;
@@ -99,8 +99,74 @@ a:not([class]) {
 			}
 		}
 	}
+
+	&:empty::after {
+		display: none;
+	}
 }
 
-a:empty::after {
-	display: none;
+a:not([class]) {
+	@extend %link;
+}
+
+a.link--inverse,
+.has-blue-400-background-color a:not([class]) {
+	@extend %link;
+
+	color: $off-white;
+	text-decoration-color: $off-white;
+
+	@supports (mask: url("../images/add.svg")) {
+		&::after {
+			background: $off-white;
+		}
+	}
+
+	&:visited {
+		color: $blue-200;
+		text-decoration-color: $blue-200;
+
+		@supports (mask: url("../images/add.svg")) {
+			&::after {
+				background: $blue-200;
+			}
+		}
+	}
+
+	&:active {
+		color: $green-200;
+		text-decoration-color: $green-200;
+
+		@supports (mask: url("../images/add.svg")) {
+			&::after {
+				background: $green-200;
+			}
+		}
+	}
+
+	&:focus {
+		background: $blue-200;
+		color: $black;
+		outline: none;
+		text-decoration: none;
+
+		@supports (mask: url("../images/add.svg")) {
+			&::after {
+				background: $black;
+			}
+		}
+	}
+
+	&:active:focus {
+		background: unset;
+		color: $green-200;
+		text-decoration: underline;
+		text-decoration-color: $green-200;
+
+		@supports (mask: url("../images/add.svg")) {
+			&::after {
+				background: $green-200;
+			}
+		}
+	}
 }

--- a/src/components/01-atoms/04-link/link.config.js
+++ b/src/components/01-atoms/04-link/link.config.js
@@ -18,6 +18,34 @@ module.exports = {
 			context: {
 				href: '#',
 			}
+		},
+		{
+			name: 'default-inverse',
+			label: 'Default (Inverse)',
+			context: {
+				className: 'link--inverse',
+				href: '/internal-link--inverse',
+				bodyClass: 'has-dark-mint-500-background-color'
+			}
+		},
+		{
+			name: 'external-inverse',
+			label: 'External (Inverse)',
+			context: {
+				href: 'https://example.com/inverse',
+				className: 'link--inverse',
+				rel: 'external',
+				bodyClass: 'has-dark-mint-500-background-color'
+			}
+		},
+		{
+			name: 'relative-inverse',
+			label: 'Relative (Inverse)',
+			context: {
+				href: '#inverse',
+				className: 'link--inverse',
+				bodyClass: 'has-dark-mint-500-background-color'
+			}
 		}
 	]
 };

--- a/src/components/01-atoms/04-link/link.njk
+++ b/src/components/01-atoms/04-link/link.njk
@@ -1,1 +1,1 @@
-<a{% if rel %} rel="{{ rel }}"{% endif %} href="{{ href }}">{{ label }}</a>{{ inlineSuffix }}
+<a{% if className %} class="{{ className }}"{% endif %}{% if rel %} rel="{{ rel }}"{% endif %} href="{{ href }}">{{ label }}</a>

--- a/src/components/01-atoms/06-call-to-action/call-to-action.config.js
+++ b/src/components/01-atoms/06-call-to-action/call-to-action.config.js
@@ -8,6 +8,14 @@ module.exports = {
 	},
 	variants: [
 		{
+			name: 'Default Inverse',
+			label: 'Default (Inverse)',
+			context: {
+				hasIcon: false,
+				bodyClass: 'has-dark-mint-500-background-color',
+			}
+		},
+		{
 			name: 'Default with Icon',
 			context: {
 				hasIcon: true

--- a/src/components/01-atoms/06-call-to-action/call-to-action.config.js
+++ b/src/components/01-atoms/06-call-to-action/call-to-action.config.js
@@ -12,6 +12,7 @@ module.exports = {
 			label: 'Default (Inverse)',
 			context: {
 				hasIcon: false,
+				class: 'wp-block-button--inverse',
 				bodyClass: 'has-dark-mint-500-background-color',
 			}
 		},


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds variants of links and calls to action for dark backgrounds. Prerequisite for home page (#161).

## Steps to test

Review components:

- https://deploy-preview-165--pinecone.netlify.com/components/preview/link--default-inverse.html
- https://deploy-preview-165--pinecone.netlify.com/components/preview/call-to-action--default-inverse.html

## Additional information

Not applicable.

## Related issues

- Blocker for #161.
- Resolves #163.