### PR TITLE
feat: add customize link to homepage feed (fixes #171)

### DIFF
--- a/src/assets/styles/layouts/_home.scss
+++ b/src/assets/styles/layouts/_home.scss
@@ -43,6 +43,18 @@
 .home__feed {
 	padding-top: rem(50);
 
+	header {
+		align-items: baseline;
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: space-between;
+
+		a {
+			margin-top: 0;
+		}
+	}
+
 	h3::before {
 		background-color: $grey-200;
 		content: "";

--- a/src/components/03-layouts/04-home/home.njk
+++ b/src/components/03-layouts/04-home/home.njk
@@ -39,7 +39,10 @@
 	{% render '@call-to-action', {standAlone: true, href: '/browse-all', label: 'Browse all resources', class: 'wp-block-button--inverse'} %}
 </section>
 <section class="home__feed">
-	<h2>{{ feed.title }}</h2>
+	<header>
+		<h2>{{ feed.title }}</h2>
+		<a href="/customize">Customize feed</a>
+	</header>
 	<h3><a href="/most-viewed">{{ 'Most viewed' }}</a></h3>
 	<div class="meta-card-wrapper">
 		<div class="card-wrapper">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds customize link to the home feed.

## Steps to test

Review home page layout: https://deploy-preview-191--pinecone.netlify.com/components/preview/home.html.

**Expected behavior:** Link appears to the right of section title and moves below the title if the link text is too long to fit.

## Additional information

Implemented using flexbox with `flex-wrap: wrap` to allow overflow to second line. This necessitated placing the section heading and the link in a container element. I used a `<header>` since we're within a named `<section>`; not sure if this adds unnecessary semantics for screen readers. Thoughts, @jhung?

## Related issues

- Fixes #171.
