### PR TITLE
fix: restore functionality to nested checkboxes (resolves #210)

### DIFF
--- a/src/assets/scripts/Pinecone/NestedCheckbox/index.js
+++ b/src/assets/scripts/Pinecone/NestedCheckbox/index.js
@@ -26,7 +26,6 @@ class NestedCheckbox {
 			...options
 		};
 
-		// this.initDisclosure();
 		this.initCustomCheckbox();
 
 		this.handleChange = this.handleChange.bind( this );
@@ -115,7 +114,7 @@ class NestedCheckbox {
 	 * @param {Event} event
 	 */
 	handleClick( event ) {
-		if ( ! 'checkbox' !== event.target.getAttribute( 'role' ) ) return;
+		if ( 'checkbox' !== event.target.getAttribute( 'role' ) ) return;
 		if ( 'checkbox' === event.target.getAttribute( 'role' ) ) {
 			this.toggleMixedCheckbox( event.target );
 		}


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR restores click functionality to the parent checkbox of nested checkboxes in the filter list.

## Steps to test

1. View the Archive component: https://deploy-preview-212--pinecone.netlify.com/components/preview/archive
2. Expand "Goals" in the filter list.
3. Check and uncheck one of the parent checkboxes (e.g. 'Build a co-op').

**Expected behavior:** The parent checkboxe's state changes, and children are checked or unchecked as appropriate.

## Additional information

Not applicable.

## Related issues

- Resolves #210.