### PR TITLE
docs: add minimal steps for incorporating Pinecone into a Django project

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,25 @@ Pinecone is built and deployed automatically to [Netlify](https://netlify.com/).
 
 ## Usage
 
-TODO: Add usage guide.
+### In a Django Project
+
+1. Download a [release](https://github.com/platform-coop-toolkit/pinecone/releases) or `git clone` this repository.
+2. Change directories and install dependencies: `npm install`
+3. Build Pinecone: `npm run build`
+4. Copy the contents of `./build/` to your project's static directory:
+
+   `cp -r ./build/ /path/to/myproj/static/myproj/`
+
+5. Add links to the JavaScript, stylesheet, and potentially the favicon somewhere in the head element of in your template, e.g., `./templates/myproj/index.html`
+   ```
+   <script src="{% static 'myproj/scripts/pinecone.umd.js' %}"></script>
+   <link href="{% static 'myproj/styles/pinecone.css' %}" rel="stylesheet">
+   <link rel="shortcut icon" href="{% static 'myproj/images/favicon.png' %}" type="image/x-icon">
+   ```
+6. This should be enough for local development. In production, these static files should be collected, e.g.,
+
+   ```
+   python manage.py collectstatic
+   ```
+
+TODO: Expand this section to other use cases.


### PR DESCRIPTION
* [ x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [ x] This isn't a duplicate of an existing pull request

## Description

Adds the minimal number of steps needed to pull Pinecone js and css into a Django project.

## Steps to test

1. I've run through the listed commands to verify.

**Expected behavior:** Pinecone styles and JavaScript should be available to the Django project.

## Additional information

N/A

## Related issues

N/A
