### PR TITLE
feat: add component and styling for favorites page

### DIFF
--- a/src/assets/styles/common/_global.scss
+++ b/src/assets/styles/common/_global.scss
@@ -37,6 +37,7 @@ body {
 main {
 	margin: 0 auto;
 	padding-bottom: rem(100);
+	position: relative;
 
 	@include grid-column-span(4, 4, 1);
 }
@@ -86,4 +87,16 @@ main {
 	main {
 		@include grid-column-span(16, 16, 1);
 	}
+}
+
+.align-right {
+	text-align: right;
+}
+
+.align-left {
+	text-align: left;
+}
+
+.align-center {
+	text-align: center;
 }

--- a/src/assets/styles/components/_button.scss
+++ b/src/assets/styles/components/_button.scss
@@ -90,6 +90,11 @@ button:-moz-focusring {
 	width: auto;
 }
 
+.align-right .button--borderless {
+	display: inline-block;
+	margin: rem(6) rem(-8) rem(6) rem(24);
+}
+
 .button--borderless.button--inverse {
 	--color: var(--off-white);
 	--outline-color: var(--off-white);
@@ -101,6 +106,19 @@ button:-moz-focusring {
 	--focus-background-color: transparent;
 	--focus-box-shadow: 0 0 0 var(--border-width) var(--dark-mint-500), 0 0 0 calc(2 * var(--border-width)) var(--outline-color);
 	--focus-box-shadow: 0 0 0 var(--border-width) var(--outline-color), 0 0 0 calc(2 * var(--border-width)) var(--parent-background-color), 0 0 0 calc(3 * var(--border-width)) var(--outline-color);
+}
+
+.button--borderless.button--destructive {
+	--color: var(--red-500);
+	--outline-color: var(--red-500);
+	--hover-color: var(--dark-mint-500);
+	--focus-color: var(--red-500);
+	--active-color: var(--white);
+	--active-background-color: var(--red-500);
+}
+
+.button--borderless.button--destructive.button--inverse {
+	// TODO.
 }
 
 .button--tag-button {

--- a/src/assets/styles/components/_notification.scss
+++ b/src/assets/styles/components/_notification.scss
@@ -7,9 +7,12 @@
 	box-shadow: 0 0 rem(10) rgba(0, 0, 0, 0.16);
 	font-family: $font-family-serif;
 	font-size: rem(16);
+	margin-bottom: $gutter;
 	padding: rem(28);
-	position: relative;
+	position: sticky;
+	top: $gutter;
 	width: 100%;
+	z-index: 1;
 
 	button {
 		position: absolute;

--- a/src/assets/styles/layouts/_favorites.scss
+++ b/src/assets/styles/layouts/_favorites.scss
@@ -1,0 +1,113 @@
+
+main {
+	position: relative;
+}
+
+.notification {
+	margin-bottom: $gutter;
+	position: sticky;
+	top: $gutter;
+	z-index: 1;
+}
+
+.remove-all-favorites,
+.remove-favorite {
+	--color: var(--red-500);
+	--hover-color: var(--red-400);
+	--active-color: var(--black);
+
+	transition: color 0.3s;
+}
+
+.remove-all {
+	text-align: right;
+}
+
+.remove-all-favorites {
+	display: inline-block;
+	margin-left: 0;
+	margin-right: rem(-8);
+}
+
+.remove-favorite {
+	float: right;
+	margin: 0 rem(-8) 0 0;
+}
+
+.page.page-template-page-favorites .card__wrapper {
+	display: grid;
+	gap: rem(20);
+	grid-template-columns: 100%;
+	grid-template-rows: 1fr 3rem;
+}
+
+@include breakpoint-up(sm) {
+	.page.page-template-page-favorites {
+		.cards {
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
+
+			@supports (display: $grid) {
+				display: grid;
+				gap: rem(30);
+				grid-template-columns: 100%;
+			}
+		}
+
+		.cards .card__wrapper {
+			margin-bottom: rem(30);
+			width: 100%;
+
+			@supports (display: $grid) {
+				margin-bottom: 0;
+			}
+		}
+
+		.card:nth-child(even) {
+			margin-left: 0;
+		}
+	}
+}
+
+@include breakpoint-up(md) {
+	.page.page-template-page-favorites {
+		.cards {
+			@supports (display: $grid) {
+				grid-template-columns: repeat(2, 1fr);
+			}
+		}
+
+		.cards .card__wrapper {
+			width: calc(50% - #{rem(30)} / 2);
+
+			@supports (display: $grid) {
+				width: 100%;
+			}
+		}
+
+		.card:nth-child(even) {
+			margin-left: rem(30);
+
+			@supports (display: $grid) {
+				margin-left: 0;
+			}
+		}
+
+		.cards .card__wrapper + .card__wrapper {
+			margin-top: 0;
+		}
+	}
+}
+
+@include breakpoint-up(lg) {
+	.page.page-template-page-favorites main {
+		@include grid-column-span(8, 12, 3);
+	}
+}
+
+@include breakpoint-up(xl) {
+	.page.page-template-page-favorites main {
+		@include grid-column-span(8, 16, 4);
+	}
+}

--- a/src/assets/styles/layouts/_favorites.scss
+++ b/src/assets/styles/layouts/_favorites.scss
@@ -1,40 +1,4 @@
-
-main {
-	position: relative;
-}
-
-.notification {
-	margin-bottom: $gutter;
-	position: sticky;
-	top: $gutter;
-	z-index: 1;
-}
-
-.remove-all-favorites,
-.remove-favorite {
-	--color: var(--red-500);
-	--hover-color: var(--red-400);
-	--active-color: var(--black);
-
-	transition: color 0.3s;
-}
-
-.remove-all {
-	text-align: right;
-}
-
-.remove-all-favorites {
-	display: inline-block;
-	margin-left: 0;
-	margin-right: rem(-8);
-}
-
-.remove-favorite {
-	float: right;
-	margin: 0 rem(-8) 0 0;
-}
-
-.page.page-template-page-favorites .card__wrapper {
+.page.page-template-page-favorites .cards .card__wrapper {
 	display: grid;
 	gap: rem(20);
 	grid-template-columns: 100%;

--- a/src/assets/styles/pinecone.scss
+++ b/src/assets/styles/pinecone.scss
@@ -40,3 +40,4 @@
 @import "layouts/footer";
 @import "layouts/archive";
 @import "layouts/resource";
+@import "layouts/favorites";

--- a/src/components/01-atoms/09-button/button.config.js
+++ b/src/components/01-atoms/09-button/button.config.js
@@ -49,6 +49,20 @@ module.exports = {
 			}
 		},
 		{
+			name: 'Destructive Borderless',
+			context: {
+				modifiers: ['borderless', 'destructive']
+			}
+		},
+		{
+			name: 'Destructive Borderless Inverse',
+			label: 'Destructive Borderless (Inverse)',
+			context: {
+				modifiers: ['borderless', 'destructive', 'inverse'],
+				bodyClass: 'has-blue-500-background-color'
+			}
+		},
+		{
 			name: 'Disc',
 			label: 'Disc',
 			context: {

--- a/src/components/01-atoms/09-button/button.njk
+++ b/src/components/01-atoms/09-button/button.njk
@@ -1,4 +1,4 @@
 {% if not standAlone %}<div class="spacer"></div>{% endif %}
-<button {% if id %}id="{{ id }}" {% endif %}type="button" class="button{% if modifiers %}{% for modifier in modifiers %} button--{{ modifier }}{% endfor %}{% endif %}">
+<button {% if id %}id="{{ id }}" {% endif %}type="button" class="button{% if modifiers %}{% for modifier in modifiers %} button--{{ modifier }}{% endfor %}{% endif %}{% if className %} {{ className }}{% endif %}">
 	{% if icon and iconPosition === 'start' %}{% render '@svg', {svg:icon}, true %}{% endif %}<span class="button__label{{ ' screen-reader-text' if labelVisuallyHidden }}">{{ label | safe }}</span>{% if icon and iconPosition === 'end' %}{% render '@svg', {svg:icon}, true %}{% endif %}
 </button>

--- a/src/components/02-molecules/01-card/card--resource.njk
+++ b/src/components/02-molecules/01-card/card--resource.njk
@@ -51,8 +51,8 @@
 			</aside>
 		</article>
 		{% if showRemoveButton %}
-		<div class="remove">
-			{% render '@button--borderless', {label: 'Remove', icon: 'delete', standAlone: true, className: 'remove-favorite'}, true %}
+		<div class="align-right">
+			{% render '@button--destructive-borderless', {label: 'Remove', icon: 'delete', standAlone: true, className: 'remove-favorite'}, true %}
 		</div>
 		{% endif %}
 	</li>

--- a/src/components/02-molecules/01-card/card--resource.njk
+++ b/src/components/02-molecules/01-card/card--resource.njk
@@ -50,6 +50,11 @@
 				{% endif %}
 			</aside>
 		</article>
+		{% if showRemoveButton %}
+		<div class="remove">
+			{% render '@button--borderless', {label: 'Remove', icon: 'delete', standAlone: true, className: 'remove-favorite'}, true %}
+		</div>
+		{% endif %}
 	</li>
 	{% if not standAlone %}
 	</ul>

--- a/src/components/02-molecules/01-card/card.config.js
+++ b/src/components/02-molecules/01-card/card.config.js
@@ -6,7 +6,7 @@ module.exports = {
 		format: 'Card',
 		name: 'Generic Card',
 		href: 'https://example.com',
-		standAlone: false
+		standAlone: false,
 	},
 	variants: [
 		{
@@ -26,7 +26,8 @@ module.exports = {
 				topicCount: 4,
 				href: 'resource',
 				favorite: true,
-				language: 'English'
+				language: 'English',
+				showRemoveButton: false
 			}
 		},
 		{

--- a/src/components/03-layouts/05-favorites/favorites.config.js
+++ b/src/components/03-layouts/05-favorites/favorites.config.js
@@ -1,0 +1,84 @@
+const faker = require( 'faker' );
+const title = require( 'title' );
+
+const formats = [
+	{
+		label: 'Audio',
+		svg: 'audio',
+	},
+	{
+		label: 'Case Study',
+		svg: 'case-study',
+	},
+	{
+		label: 'Toolkit',
+		svg: 'toolkit',
+	},
+	{
+		label: 'Educational Curriculum',
+		svg: 'educational-curriculum',
+	},
+	{
+		label: 'Video',
+		svg: 'video',
+	},
+	{
+		label: 'Article',
+		svg: 'article',
+	},
+	{
+		label: 'Book',
+		svg: 'book',
+	},
+	{
+		label: 'Academic Paper',
+		svg: 'academic-paper',
+	},
+	{
+		label: 'Report',
+		svg: 'report',
+	},
+	{
+		label: 'Presentation Slides',
+		svg: 'presentation',
+	},
+	{
+		label: 'Online Training',
+		svg: 'online-training',
+	},
+];
+
+const resourceCount = 8;
+const resourceData = [];
+
+for ( let i = 0; i < resourceCount; i++ ) {
+	const thisFormat = formats[i];
+
+	resourceData.push( {
+		id: i,
+		modifier: 'resource',
+		format: thisFormat.label,
+		formatIcon: thisFormat.svg,
+		name: 'Resource',
+		title: title( faker.lorem.words( faker.random.number( { min: 4, max: 12 } ) ) ),
+		byline: title( faker.lorem.words( faker.random.number( { min: 2, max: 4 } ) ) ),
+		locality: faker.address.country(),
+		topics: [title( faker.company.catchPhraseNoun() ), title( faker.company.catchPhraseNoun() )],
+		topicCount: faker.random.number( { min: 3, max: 7 } ),
+		href: 'resource',
+		standAlone: true,
+		showRemoveButton: true
+	} );
+}
+
+module.exports = {
+	title: 'Favorites',
+	status: 'wip',
+	context: {
+		bodyClass: 'page page-template-page-favorites',
+		hasMenu: true,
+		hasFooter: true,
+		title: 'Favorites',
+		cards: resourceData
+	}
+};

--- a/src/components/03-layouts/05-favorites/favorites.njk
+++ b/src/components/03-layouts/05-favorites/favorites.njk
@@ -1,0 +1,14 @@
+<div class="page-header">
+	<p>{% render '@link--breadcrumb', {label: 'Home', href: '/'}, true %}</p>
+	<h1>{{ title }}</h1>
+</div>
+<div class="remove-all">
+	{% render '@button--borderless', {label: 'Remove all', icon: 'delete', standAlone: true, className: 'remove-all-favorites'}, true %}
+</div>
+<div class="resource-list">
+	<ul class="cards">
+	{% for card in cards %}
+	{% render '@card--resource', card %}
+	{% endfor %}
+	</ul>
+</div>

--- a/src/components/03-layouts/05-favorites/favorites.njk
+++ b/src/components/03-layouts/05-favorites/favorites.njk
@@ -2,8 +2,8 @@
 	<p>{% render '@link--breadcrumb', {label: 'Home', href: '/'}, true %}</p>
 	<h1>{{ title }}</h1>
 </div>
-<div class="remove-all">
-	{% render '@button--borderless', {label: 'Remove all', icon: 'delete', standAlone: true, className: 'remove-all-favorites'}, true %}
+<div class="align-right">
+	{% render '@button--destructive-borderless', {label: 'Remove all', icon: 'delete', standAlone: true, className: 'remove-all-favorites'}, true %}
 </div>
 <div class="resource-list">
 	<ul class="cards">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

- Adds favorites page layout.
- Add align-right and align-left classes.
- Make notifications sticky (resolves #241).
- Add destructive borderless button variant (needs adjusted active and focus states, dependent on #240).

## Steps to test

Review layout: https://deploy-preview-242--pinecone.netlify.com/components/preview/favorites.html

## Additional information

Not applicable.

## Related issues

- Resolves #205.
- Resolves #241.