### PR TITLE
fix: resolve issue with byline appearing inline with resource title on home feed

### DIFF
--- a/src/assets/styles/layouts/_home.scss
+++ b/src/assets/styles/layouts/_home.scss
@@ -39,7 +39,13 @@
 .home__feed {
 	padding-top: $gutter;
 
-	header {
+	> header {
+		align-items: baseline;
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: space-between;
+
 		a {
 			margin-top: 0;
 		}

--- a/src/assets/styles/layouts/_home.scss
+++ b/src/assets/styles/layouts/_home.scss
@@ -40,12 +40,6 @@
 	padding-top: $gutter;
 
 	header {
-		align-items: baseline;
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
-		justify-content: space-between;
-
 		a {
 			margin-top: 0;
 		}

--- a/src/components/layouts/home/home.njk
+++ b/src/components/layouts/home/home.njk
@@ -3,7 +3,7 @@
 	<p class="subhead">{{ subhead }}</p>
 </div>
 <section class="home__search">
-	{% render '@search', {standAlone: true, modifier: 'inverse', placeholder: 'Search resource name, publisher, or topic…'}, true %}
+	{% render '@search-form', {standAlone: true, modifier: 'inverse', placeholder: 'Search resource name, publisher, or topic…'}, true %}
 	{# TODO: Add saved searches. #}
 </section>
 <section class="home__browse">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes #257 .

## Steps to test

1. Go to Layouts > Home
2. Notice how byline is on a separate line from the title.
3. Edit `home.config.js` lines 63 and 64 to generate 1 word title and bylines (i.e. min: 1, max: 1).
4. Rebuild pinecone with this new configuration `npm run build`
5. Run `fractal start`
6. Go to Layouts > Home
7. Notice that bylines are still on separate lines even though the titles and bylines are short.

**Expected behavior:** <!-- What should happen -->
The byline for a resource should be on its own line regardless of the length of the title or byline string.

## Additional information

Not applicable.

## Related issues

Resolves #257 .