### PR TITLE
feat: add image atom, blur images with missing alt tags

### DIFF
--- a/src/assets/styles/components/_image.scss
+++ b/src/assets/styles/components/_image.scss
@@ -1,0 +1,11 @@
+img {
+	border-style: none;
+	display: block;
+	height: auto;
+	max-width: 100%;
+	vertical-align: middle;
+}
+
+img:not([alt]) {
+	filter: blur(rem(10));
+}

--- a/src/assets/styles/pinecone.scss
+++ b/src/assets/styles/pinecone.scss
@@ -17,6 +17,7 @@
 @import "components/divider";
 @import "components/button";
 @import "components/icons";
+@import "components/image";
 @import "components/input";
 @import "components/link";
 @import "components/link-list";

--- a/src/components/atoms/image/image.config.js
+++ b/src/components/atoms/image/image.config.js
@@ -1,0 +1,27 @@
+module.exports = {
+	title: 'Image',
+	status: 'wip',
+	order: 11,
+	context: {
+		src: '/images/person.jpg',
+		width: 367,
+		height: 250,
+		alt: 'Photograph of Trebor Scholz',
+		role: false
+	},
+	variants: [
+		{
+			name: 'Decorative',
+			context: {
+				alt: '',
+				role: 'presentation'
+			}
+		},
+		{
+			name: 'Missing Alternative Text',
+			context: {
+				alt: false
+			}
+		}
+	]
+};

--- a/src/components/atoms/image/image.njk
+++ b/src/components/atoms/image/image.njk
@@ -1,0 +1,10 @@
+{% set altAttribute = false %}
+{% if alt !== false %}
+	{% set altAttribute = 'alt="' + alt + '"' %}
+{% endif %}
+{% set roleAttribute = false %}
+{% if role !== false %}
+	{% set roleAttribute = 'role="' + role + '"' %}
+{% endif %}
+
+<img {{ roleAttribute | safe if roleAttribute else '' }} src="{{ src }}" width="{{ width }}" height="{{ height }}" {{ altAttribute | safe if altAttribute else '' }} />

--- a/src/components/molecules/card/card.config.js
+++ b/src/components/molecules/card/card.config.js
@@ -78,7 +78,12 @@ module.exports = {
 				title: 'Who Owns the World?',
 				date: 'Nov 12, 2019',
 				href: 'blog',
-				image: '/images/blog.jpg'
+				image: {
+					src: '/images/blog.jpg',
+					width: 367,
+					height: 165,
+					alt: 'Photograph of Cataki workers'
+				}
 			}
 		},
 		{
@@ -91,7 +96,12 @@ module.exports = {
 				title: 'SEWA Federation',
 				locality: 'Gujarat, India',
 				href: 'story',
-				image: '/images/story.jpg'
+				image: {
+					src: '/images/story.jpg',
+					width: 367,
+					height: 165,
+					alt: 'Photograph of SEWA workers'
+				}
 			}
 		},
 		{
@@ -103,7 +113,12 @@ module.exports = {
 				title: 'Trebor Scholz',
 				description: 'Founding Director, Institute for the Cooperative Digital Economy',
 				href: 'person',
-				image: '/images/person.jpg'
+				image: {
+					src: '/images/person.jpg',
+					width: '',
+					height: '',
+					alt: 'Photograph of Trebor Scholz',
+				}
 			}
 		},
 		{

--- a/src/components/molecules/card/card.njk
+++ b/src/components/molecules/card/card.njk
@@ -5,7 +5,7 @@
 		<article class="card{% if modifier %} card--{{ modifier }}{% endif %}">
 			{% if image %}
 			<figure class="card__image">
-				<img src="{{ image }}" alt="Image for this {{ modifier }}."/>
+				{% render '@image', image, true %}
 			</figure>
 			{% endif %}
 			<header>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds a component for images, with three variants:

- Default (with `alt` tag)
- Decorative (with `role="presentation"` and empty `alt` tag)
- Missing Alt Text (with no `alt` tag, blurred 10px)

## Steps to test

1. Review image components.

**Expected behavior:** Images behave as expected for sighted users and assistive technology users.

## Additional information

- See https://github.com/hankchizljaw/modern-css-reset/pull/22
- See https://github.com/jensimmons/cssremedy/blob/master/css/remedy.css#L56-L73
- See https://www.w3.org/WAI/tutorials/images/decorative/

## Related issues

- Resolves #230.
