### PR TITLE
feat: add subscription indicator to resources (resolves #268)

### DIFF
--- a/src/assets/styles/components/_card.scss
+++ b/src/assets/styles/components/_card.scss
@@ -181,6 +181,14 @@
 	}
 }
 
+.card__meta.card__subscription {
+	color: var(--red-500);
+
+	svg {
+		color: inherit;
+	}
+}
+
 .card--resource {
 	@include card($red-400, var(--dark-mint-500), false);
 

--- a/src/assets/styles/layouts/_resource.scss
+++ b/src/assets/styles/layouts/_resource.scss
@@ -10,6 +10,14 @@
 	color: var(--grey-500);
 }
 
+.resource__meta.resource__subscription {
+	color: var(--red-500);
+
+	svg {
+		color: inherit;
+	}
+}
+
 h1 + .resource__meta {
 	margin-top: rem(24);
 }

--- a/src/components/layouts/archive/archive.config.js
+++ b/src/components/layouts/archive/archive.config.js
@@ -79,6 +79,7 @@ for ( let i = 0; i < resourceCount; i++ ) {
 		topicCount: faker.random.number( { min: 3, max: 7 } ),
 		href: 'resource',
 		standAlone: true,
+		requiresSubscription: i % 2 ? true : false
 	} );
 }
 

--- a/src/components/layouts/favorites/favorites.config.js
+++ b/src/components/layouts/favorites/favorites.config.js
@@ -67,7 +67,8 @@ for ( let i = 0; i < resourceCount; i++ ) {
 		topicCount: faker.random.number( { min: 3, max: 7 } ),
 		href: 'resource',
 		standAlone: true,
-		showRemoveButton: true
+		showRemoveButton: true,
+		requiresSubscription: i % 2 ? true : false
 	} );
 }
 

--- a/src/components/layouts/resource/resource.config.js
+++ b/src/components/layouts/resource/resource.config.js
@@ -14,6 +14,7 @@ module.exports = {
 		locality: 'Canada',
 		language: 'English',
 		date: 2019,
-		byline: 'Some Co-operator'
+		byline: 'Some Co-operator',
+		requiresSubscription: true
 	}
 };

--- a/src/components/layouts/resource/resource.njk
+++ b/src/components/layouts/resource/resource.njk
@@ -1,6 +1,9 @@
 <article class="resource">
 	<div class="page-header resource__header">
 		<h1>{{ title }}</h1>
+		{% if requiresSubscription %}
+		<p class="resource__meta resource__subscription">{% render '@svg', {svg:'lock'}, true %} <span aria-hidden="true">Subscription required</span><span class="screen-reader-text">Subscription required to access this resource</span></p>
+		{% endif %}
 		{% if byline %}
 		<div class="resource__meta resource__byline">{% render '@svg', {svg:'author'}, true %} By {{ byline | safe }}</div>
 		{% endif %}

--- a/src/components/layouts/search-results/search-results.config.js
+++ b/src/components/layouts/search-results/search-results.config.js
@@ -79,6 +79,7 @@ for ( let i = 0; i < resourceCount; i++ ) {
 		topicCount: faker.random.number( { min: 3, max: 7 } ),
 		href: 'resource',
 		standAlone: true,
+		requiresSubscription: i % 2 ? true : false
 	} );
 }
 

--- a/src/components/molecules/card/card--resource.njk
+++ b/src/components/molecules/card/card--resource.njk
@@ -7,6 +7,9 @@
 				<h3 class="card__title" >
 					<a class="card__link" href="{{ href }}">{{ title | safe }}</a>
 				</h3>
+				{% if requiresSubscription %}
+				<p class="card__meta card__subscription">{% render '@svg', {svg:'lock'}, true %} <span aria-hidden="true">Subscription required</span><span class="screen-reader-text">Subscription required to access this resource</span></p>
+				{% endif %}
 				{% if byline %}
 					<p class="card__byline">{% render '@svg', {svg:'author'}, true %} By {{ byline | safe }}</p>
 				{% endif %}

--- a/src/components/molecules/card/card.config.js
+++ b/src/components/molecules/card/card.config.js
@@ -28,7 +28,8 @@ module.exports = {
 				href: 'resource',
 				favorite: true,
 				language: 'English',
-				showRemoveButton: false
+				showRemoveButton: false,
+				requiresSubscription: true
 			}
 		},
 		{


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Resolves #268.

## Steps to test

1. Review resource card, archive, and single resource views.

**Expected behavior:** Subscription indicator appears.

## Additional information

Not applicable.

## Related issues

- Resolves #268.