### PR TITLE
fix: don't make aria-live containers inert

### DIFF
--- a/src/assets/scripts/Pinecone/Dialog/index.js
+++ b/src/assets/scripts/Pinecone/Dialog/index.js
@@ -57,7 +57,7 @@ class Dialog {
 	 * @param {Function} callback
 	 */
 	invokeDialog( callback ) {
-		const elems = document.querySelectorAll( 'body > *' );
+		const elems = document.querySelectorAll( 'body > *:not([aria-live])' );
 		Array.prototype.forEach.call( elems, ( elem ) => {
 			elem.setAttribute( 'inert', 'inert' );
 		} );

--- a/src/assets/scripts/Pinecone/FilterList/index.js
+++ b/src/assets/scripts/Pinecone/FilterList/index.js
@@ -31,7 +31,7 @@ class FilterList {
 	handleOverlay( event ) {
 		if ( ! event.target.closest( this.config.showCtrlSelector ) && ! event.target.closest( this.config.hideCtrlSelector ) ) return false;
 
-		const elems = document.querySelectorAll( 'body > *' );
+		const elems = document.querySelectorAll( 'body > *:not([aria-live])' );
 
 		if ( event.target.closest( this.config.showCtrlSelector ) ) {
 			document.body.classList.add( 'has-modal' );


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

The dialog component sets direct descendants of the body to `inert`, which interferes with [@wordpress/a11y](https://www.npmjs.com/package/@wordpress/a11y) and the `aria-live` containers it uses. This PR ensures that aria-live containers are not set to inert.

## Steps to test

When invoking a dialog, direct descendants of the `body` tag with an `aria-live` attribute should not be set to `inert`.

## Additional information

Not applicable.

## Related issues

- Related to https://github.com/platform-coop-toolkit/coop-library/issues/200.