### PR TITLE
fix: date added margin

### DIFF
--- a/src/assets/styles/layouts/_resource.scss
+++ b/src/assets/styles/layouts/_resource.scss
@@ -61,6 +61,10 @@ h1 + .resource__meta {
 	}
 }
 
+.resource__actions + .resource__meta {
+	margin-bottom: rem(24);
+}
+
 .resource__related {
 	padding-bottom: rem(92);
 	padding-top: rem(64);
@@ -130,10 +134,6 @@ h1 + .resource__meta {
 	.resource__actions {
 		margin-bottom: rem(80);
 		margin-top: rem(28);
-	}
-
-	.resource__actions + .resource__meta {
-		margin-bottom: rem(24);
 	}
 
 	.resource__related {


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Gives the date added field a bottom margin on single resource view (tablet and below).

## Steps to test

1. Inspect single resource view on tablet/mobile.

**Expected behavior:** Date added has a bottom margin of 1.5rem.

## Additional information

Not applicable.

## Related issues

- Resolves https://github.com/platform-coop-toolkit/coop-library/issues/247.
