### PR TITLE
fix: typo "your" to "you"

### DIFF
--- a/src/components/molecules/dialog/dialog.config.js
+++ b/src/components/molecules/dialog/dialog.config.js
@@ -6,7 +6,7 @@ module.exports = {
 		buttonIcon: 'delete',
 		buttonLabel: 'Remove favorite',
 		dialogTitle: 'Remove favorite',
-		dialogQuestion: 'Are your sure you want to remove this resource from your favorites?',
+		dialogQuestion: 'Are you sure you want to remove this resource from your favorites?',
 		dialogConfirm: 'Yes, remove',
 		dialogDismiss: 'No, don&rsquo;t remove'
 	},


### PR DESCRIPTION
I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)

## Description

Fixing typo in Dialog example.
