### PR TITLE
fix: filter list checkbox properly hidden and has proper IDs

### DIFF
--- a/src/assets/styles/components/_input.scss
+++ b/src/assets/styles/components/_input.scss
@@ -264,6 +264,10 @@ input[type="checkbox"],
 	}
 }
 
+[role="checkbox"] + input[type="checkbox"] {
+	display: none;
+}
+
 input[type="radio"] + label,
 input[type="checkbox"] + label {
 	font-weight: $font-weight-normal;

--- a/src/components/molecules/filter-list/filter-list.njk
+++ b/src/components/molecules/filter-list/filter-list.njk
@@ -16,7 +16,7 @@
 					<li>
 						{% if term.children %}
 							{% set count = term.children.length %}
-							{% render '@checkbox', {label: term.label, value: term.label | slugify, name: label | slugify, standAlone: false, inverse: true}, true %}
+							{% render '@checkbox', {label: term.label, value: term.label | slugify, name: term.label | slugify, standAlone: false, inverse: true}, true %}
 							<span class="filter-disclosure-label" hidden>show {{ count }} subtopics for "{{ term.label }}"</span>
 							<span class="supplementary-label" hidden> (and {{ count }} subtopics)</span>
 							<ul class="input-group input-group__descendant">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Resolve an issue where invisible checkbox in filter-list was receiving keyboard focus. Also fixes an issue where filter-list checkbox IDs were not properly populated.

## Steps to test

1. Go to filter-list
2. Use keyboard to expand and tab through list of filters
3. Focus should move from visible element to visible element in a predictable and expected way.

## Related issues

Fixes #317.
