### PR TITLE
Fix/filter parent state

### DIFF
--- a/src/assets/scripts/Pinecone/NestedCheckbox/index.js
+++ b/src/assets/scripts/Pinecone/NestedCheckbox/index.js
@@ -63,7 +63,17 @@ class NestedCheckbox {
 	 * Get custom status for the top-level checkbox.
 	 */
 	getCustomState() {
-		return false;
+		const checkedSubInputs = this.subGroup.querySelectorAll( '[type="checkbox"]:checked' );
+
+		let state = false;
+
+		if ( checkedSubInputs.length === this.subInputs.length ) {
+			state = true;
+		} else if (  0 < checkedSubInputs.length ) {
+			state = 'mixed';
+		}
+
+		return state;
 	}
 
 	/**

--- a/src/components/atoms/form-elements/custom-checkboxes/custom-checkboxes.config.js
+++ b/src/components/atoms/form-elements/custom-checkboxes/custom-checkboxes.config.js
@@ -7,11 +7,27 @@ module.exports = {
 		label: 'Nested Checkboxes',
 		items: [
 			{
-				label: 'Parent item 1',
+				label: 'Parent item 1 (initially unchecked)',
 				children: [
-					'Sub item 1',
-					'Sub item 2',
-					'Sub item 3'
+					{ label: 'Sub item 1' },
+					{ label: 'Sub item 2' },
+					{ label: 'Sub item 3' }
+				]
+			},
+			{
+				label: 'Parent item 2 (initially mixed)',
+				children: [
+					{ label: 'Sub item 4', checked: true },
+					{ label: 'Sub item 5'},
+					{ label: 'Sub item 6', checked: true }
+				]
+			},
+			{
+				label: 'Parent item 3 (initially all checked)',
+				children: [
+					{ label: 'Sub item 7', checked: true },
+					{ label: 'Sub item 8', checked: true },
+					{ label: 'Sub item 9', checked: true }
 				]
 			}
     ]

--- a/src/components/atoms/form-elements/custom-checkboxes/custom-checkboxes.njk
+++ b/src/components/atoms/form-elements/custom-checkboxes/custom-checkboxes.njk
@@ -5,7 +5,7 @@
 			{% render '@checkbox', {label: item.label, value: item.label | slugify, name: item.label | slugify, standAlone: false}, true %}
 			<ul class="input-group input-group__descendant{% if inverse %} input-group--inverse{% endif %}{% if modifiers %}{% for modifier in modifiers %} input-group--{{ modifier }}{% endfor %}{% endif %}">
 				{% for child in item.children %}
-				<li>{% render '@checkbox', {label: child, value: child | slugify, name: child | slugify, standAlone: false}, true %}</li>
+				<li>{% render '@checkbox', {label: child.label, value: child.label | slugify, name: child.label | slugify, checked: child.checked, standAlone: false}, true %}</li>
 				{% endfor %}
 			</ul>
     {% endif %}


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fix an issue where a parent checkbox was not visually setting a state on load. This would create the wrong impression that a parent is unchecked, but in fact it is (see #322 ).

## Steps to test

1. Go to the Custom Checkbox component
2. Notice how each parent checkbox now reflects a checked, mixed, or unchecked state depending on initial state of the child checkboxes.

## Related issues

Fixes #322 
