### PR TITLE
fix: resolve 404 errors for icons

### DIFF
--- a/src/assets/images/curriculum.svg
+++ b/src/assets/images/curriculum.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path id="educational-curriculum" d="m15 2h-10a2 2 0 0 0 -2 2v1h-1v2h1v2h-1v2h1v2h-1v2h1v1a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-12a2 2 0 0 0 -2-2zm-10 14v-1h1v-2h-1v-2h1v-2h-1v-2h1v-2h-1v-1h6v12h2v-12h2v12z" fill="currentColor"/></svg>
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path id="curriculum" d="m15 2h-10a2 2 0 0 0 -2 2v1h-1v2h1v2h-1v2h1v2h-1v2h1v1a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-12a2 2 0 0 0 -2-2zm-10 14v-1h1v-2h-1v-2h1v-2h-1v-2h1v-2h-1v-1h6v12h2v-12h2v12z" fill="currentColor"/></svg>

--- a/src/components/layouts/favorites/favorites.config.js
+++ b/src/components/layouts/favorites/favorites.config.js
@@ -16,7 +16,7 @@ const formats = [
 	},
 	{
 		label: 'Educational Curriculum',
-		svg: 'educational-curriculum',
+		svg: 'curriculum',
 	},
 	{
 		label: 'Video',

--- a/src/components/layouts/home/home.config.js
+++ b/src/components/layouts/home/home.config.js
@@ -16,7 +16,7 @@ const formats = [
 	},
 	{
 		label: 'Educational Curriculum',
-		svg: 'educational-curriculum',
+		svg: 'curriculum',
 	},
 	{
 		label: 'Video',
@@ -32,7 +32,7 @@ const formats = [
 	},
 	{
 		label: 'Academic Paper',
-		svg: 'academic-paper',
+		svg: 'academic',
 	},
 	{
 		label: 'Report',


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Resolves 404 errors for educational curriculum and academic paper icons on home layout.

## Steps to test

1. Visit home layout.

**Expected behavior:** All resource card icons are properly displayed.

## Additional information

Props @erictheise for catching this.

## Related issues

Not applicable.