### PR TITLE
fix: prevent top level checkbox overlap (fixes #292)

### DIFF
--- a/src/assets/styles/components/_input.scss
+++ b/src/assets/styles/components/_input.scss
@@ -254,6 +254,7 @@ input[type="radio"] {
 input[type="checkbox"],
 [role="checkbox"] {
 	cursor: default;
+	margin-right: rem(40);
 
 	&::before {
 		margin-right: rem(8);

--- a/src/components/layouts/archive/archive.config.js
+++ b/src/components/layouts/archive/archive.config.js
@@ -137,7 +137,7 @@ module.exports = {
 						]
 					},
 					{
-						label: 'Build a platform',
+						label: 'Build a platform or protocol',
 						children: [
 							'Understand the design process',
 							'Design for privacy',


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This fixes an issue where a top-level checkbox in the filter list would be overlapped by the disclosure button.

## Steps to test

1. Review component: https://deploy-preview-347--pinecone.netlify.app/components/preview/archive--default

**Expected behavior:** Goals &rarr; Build a Platform or Protocol should wrap instead of being overlapped by the disclosure button as it is here: https://resources.platform.coop/resources/

## Additional information

Not applicable.

## Related issues

Fixes #292.
