### PR TITLE
Fixes and tweaks to state styles

### DIFF
--- a/src/assets/styles/components/_accordion.scss
+++ b/src/assets/styles/components/_accordion.scss
@@ -72,6 +72,7 @@
 	font-weight: $font-weight-bold;
 	height: rem(54);
 	line-height: normal;
+	margin: calc(2 * var(--border-width)) 0;
 	padding-bottom: rem(14);
 	padding-left: 0;
 	padding-right: 0;

--- a/src/assets/styles/components/_button.scss
+++ b/src/assets/styles/components/_button.scss
@@ -153,7 +153,7 @@ button:-moz-focusring {
 	&[aria-pressed="true"],
 	&[aria-checked="true"] {
 		--color: var(--off-white);
-		--background-color: var(--blue-600);
+		--background-color: var(--blue-400);
 		--border-color: var(--background-color);
 
 		--focus-background-color: var(--background-color);

--- a/src/assets/styles/components/_menu--home.scss
+++ b/src/assets/styles/components/_menu--home.scss
@@ -7,9 +7,6 @@
 	--active-color: var(--blue-200);
 	--focus-color: var(--off-white);
 	--focus-background-color: transparent;
-	--focus-box-shadow: 0 0 0 var(--border-width) var(--dark-mint-500), 0 0 0 calc(2 * var(--border-width)) var(--outline-color);
-	--focus-box-shadow: 0 0 0 var(--border-width) var(--outline-color), 0 0 0 calc(2 * var(--border-width)) var(--parent-background-color), 0 0 0 calc(3 * var(--border-width)) var(--outline-color);
-
 }
 
 @include breakpoint-up(md) {

--- a/src/assets/styles/components/_menu-button.scss
+++ b/src/assets/styles/components/_menu-button.scss
@@ -15,7 +15,6 @@
 	--active-color: var(--blue-200);
 	--focus-color: var(--off-white);
 	--focus-background-color: transparent;
-	--focus-box-shadow: 0 0 0 var(--border-width) var(--outline-color), 0 0 0 calc(2 * var(--border-width)) var(--parent-background-color), 0 0 0 calc(3 * var(--border-width)) var(--outline-color);
 }
 
 .menu-button__menu {

--- a/src/assets/styles/components/_search.scss
+++ b/src/assets/styles/components/_search.scss
@@ -81,8 +81,9 @@
 		--outline-color: var(--blue-600);
 		--hover-color: var(--blue-600);
 		--hover-background-color: var(--blue-150);
-		--active-color: var(--blue-400);
-		--active-background-color: var(--background-color);
+		--active-border-color: var(--blue-50);
+		--active-color: var(--blue-50);
+		--active-background-color: var(--parent-background-color);
 		--focus-color: var(--blue-600);
 		--focus-background-color: var(--background-color);
 		--focus-border-color: var(--blue-50);

--- a/src/assets/styles/layouts/_home.scss
+++ b/src/assets/styles/layouts/_home.scss
@@ -45,6 +45,11 @@
 		position: relative;
 		top: rem(-25);
 	}
+
+	.search-form.search-form--inverse .button--search {
+		--active-background-color: var(--blue-500);
+		--active-color: var(--blue-50);
+	}
 }
 
 .home__browse {


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

- Fixes #363 - Search focus borders appear as different widths
- Fixes #364 - Search inverts when active. 
- Fixes #365 - Menu button inverted focus and active style
- Fixes #368 - Radio group selected state
- Fixes #401 - Accordion has bottom border when active

## Steps to test

Search button:
1. Test active state of the search button on the following:
   * Search button
   * Search form
   * Home Layout
2. Search focus/active borders should appear consistent on both the input field and search button (see #363). Note: existing issues with box shadow rendering on Firefox may cause outer and inner borders to appear different widths. See #360).
3. The search button should invert when active See #364 .

Menu button:
1. Test the focus and active state on the following:
   * Menu button
   * Page layout (mobile)
   * Home layout (mobile)
2. The focus border should be consistent in width and spacing across default and inverted styles. See #365 .

Radio group:
1. Verify that the checked option in the Radio Group is Blue-500

Accordion:
1. Test the active or focus state for the filter accordion button on the Archive layout.
2. The top border of the next accordion button should not overlap with the active or focus styling (see #401) 